### PR TITLE
Fix complex schema pickling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ The format is largely inspired by keepachangelog_.
 
 .. _0.1.1:
 
+0.4.1 - 2017-07-18
+==================
+
+Bugfixes
+--------
+
+- Fix complex schema unpickling. When schemas contained typed object
+  references with their own schema, unpickling wouldn't properly
+  register the unpickled schemas with the mapped_object proxy
+  factory, and would fail to build the required objects with a KeyError
+
 0.4.0 - 2017-07-12
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ else:
     extra['ext_modules'] = lazy_modules()
     extra['setup_requires'] = setup_requires
 
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 
 version_path = os.path.join(os.path.dirname(__file__), 'sharedbuffers', '_version.py')
 if not os.path.exists(version_path):


### PR DESCRIPTION
Fix the case of complex schema unpickling, where typed object
references would not register the unpickled shcema with mapped_object
and would end up throwing KeyError