### PR TITLE
Fix mapped_dict idmap handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Changes
 
 - Allow building with Cython 0.28 and above
 - Use `v` prefix on releases to have fixed links for this document
+- mapped_list now returns actual lists and not a subclass
 
 v0.4.8 - 2018-05-28
 ===================

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -253,10 +253,11 @@ class mapped_tuple(tuple):
                     # these are wrapped objects, not plain objects, so make sure they have distinct xid
                     xid = id(x) | (0xFL << 64)
                     if xid not in idmap:
-                        idmap[xid] = offs + implicit_offs
+                        idmap[xid] = val_offs = offs + implicit_offs
                         mx = mapped_object(x)
                         offs = mx.pack_into(mx, buf, offs, idmap, implicit_offs)
-                    val_offs = idmap[xid]
+                    else:
+                        val_offs = idmap[xid]
                     index[i] = val_offs - baseoffs - implicit_offs
 
             # write index
@@ -335,7 +336,13 @@ class mapped_dict(dict):
     def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0):
         keys = list(obj)
         values = [obj[k] for k in keys]
-        return mapped_list.pack_into([keys, values], buf, offs, idmap, implicit_offs)
+        rv = mapped_list.pack_into([keys, values], buf, offs, idmap, implicit_offs)
+        if idmap is not None:
+            # These are ephemeral objects, we don't want them to stay around in the idmap
+            # or baaaaaad things will happen
+            idmap.pop(id(keys) | (0xFL << 64), None)
+            idmap.pop(id(values) | (0xFL << 64), None)
+        return rv
 
     @classmethod
     def unpack_from(cls, buf, offs, idmap = None):
@@ -994,9 +1001,11 @@ class mapped_unicode(unicode):
         return rv
 
 class mapped_decimal(Decimal):
+    PACKER = struct.Struct('=q')
+
     @classmethod
     @cython.locals(offs = cython.longlong, implicit_offs = cython.longlong, exponent = cython.longlong, sign = cython.uchar)
-    def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0, packer = struct.Struct('=q')):
+    def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0):
         if idmap is not None:
             objid = id(obj)
             idmap[objid] = offs + implicit_offs
@@ -1004,18 +1013,20 @@ class mapped_decimal(Decimal):
         if not isinstance(obj, (Decimal, cDecimal)):
             obj = cDecimal(obj)
 
+        packer = cls.PACKER
         sign, digits, exponent = obj.as_tuple()
         packer.pack_into(buf, offs, (exponent << 1) | sign)
         offs += packer.size
 
-        return mapped_tuple.pack_into(digits, buf, offs, idmap, implicit_offs)
+        return mapped_tuple.pack_into(digits, buf, offs, None, implicit_offs)
 
     @classmethod
     @cython.locals(offs = cython.longlong, exponent = cython.longlong, sign = cython.uchar)
-    def unpack_from(cls, buf, offs, idmap = None, packer = struct.Struct('=q')):
+    def unpack_from(cls, buf, offs, idmap = None):
         if idmap is not None and offs in idmap:
             return idmap[offs]
 
+        packer = cls.PACKER
         exponent, = packer.unpack_from(buf, offs)
         sign = exponent & 0x1
 
@@ -1027,13 +1038,16 @@ class mapped_decimal(Decimal):
         return rv
 
 class mapped_datetime(datetime):
+    PACKER = struct.Struct('=q')
+
     @classmethod
     @cython.locals(offs = cython.longlong, implicit_offs = cython.longlong, timestamp = cython.longlong)
-    def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0, packer = struct.Struct('=q')):
+    def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0):
         if idmap is not None:
             objid = id(obj)
             idmap[objid] = offs + implicit_offs
 
+        packer = cls.PACKER
         timestamp = int(time.mktime(obj.timetuple()))
         packer.pack_into(buf, offs, (timestamp << 20) + obj.microsecond)
 
@@ -1041,10 +1055,11 @@ class mapped_datetime(datetime):
 
     @classmethod
     @cython.locals(offs = cython.longlong, timestamp = cython.longlong, microseconds = cython.ulong)
-    def unpack_from(cls, buf, offs, idmap = None, packer = struct.Struct('=q')):
+    def unpack_from(cls, buf, offs, idmap = None):
         if idmap is not None and offs in idmap:
             return idmap[offs]
 
+        packer = cls.PACKER
         timestamp, = packer.unpack_from(buf, offs)
         microseconds = timestamp & 0xFFFFF
         rv =  datetime.fromtimestamp(timestamp >> 20) + timedelta(microseconds=microseconds)

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -1074,13 +1074,16 @@ class mapped_datetime(datetime):
         return rv
 
 class mapped_date(date):
+    PACKER = struct.Struct('=q')
+
     @classmethod
     @cython.locals(offs = cython.longlong, implicit_offs = cython.longlong, timestamp = cython.longlong)
-    def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0, packer = struct.Struct('=q')):
+    def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0):
         if idmap is not None:
             objid = id(obj)
             idmap[objid] = offs + implicit_offs
 
+        packer = cls.PACKER
         timestamp = int(time.mktime(obj.timetuple()))
         packer.pack_into(buf, offs, timestamp)
 
@@ -1088,10 +1091,11 @@ class mapped_date(date):
 
     @classmethod
     @cython.locals(offs = cython.longlong, timestamp = cython.longlong)
-    def unpack_from(cls, buf, offs, idmap = None, packer = struct.Struct('=q')):
+    def unpack_from(cls, buf, offs, idmap = None):
         if idmap is not None and offs in idmap:
             return idmap[offs]
 
+        packer = cls.PACKER
         timestamp, = packer.unpack_from(buf, offs)
         rv =  date.fromtimestamp(timestamp)
 

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -1619,6 +1619,12 @@ class MappedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, Dic
         {'a': 1, 1: 'a', frozenset(): 1.0, (1, 2): 80000 },
     ]
 
+    def testMappedDictIdmapHandling(self):
+        buf = bytearray(1024)
+        mapped_struct.mapped_list.pack_into(self.TEST_DICTS, buf, 0)
+        unpacked = mapped_struct.mapped_list.unpack_from(buf, 0)
+        self.assertEqual(unpacked, self.TEST_DICTS)
+
 class MappedDatetimePackingTest(unittest.TestCase):
 
     TEST_VALUE_NOW = datetime.now()


### PR DESCRIPTION
It leaves ephemeral objects (keys, values) in the idmap, causing
all kinds of weird mixups