### PR TITLE
Object pools and safer/better ID maps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added
 - Add support for mapping from uncompressed zip files
 - Treat long as int
 - More informative packing error messages
+- Add pool module with dynamic object pool implementations, allowing
+  incremental build of large object heirarchies/collections.
 
 Changes
 -------
@@ -31,6 +33,11 @@ Changes
 - Allow building with Cython 0.28 and above
 - Use `v` prefix on releases to have fixed links for this document
 - mapped_list now returns actual lists and not a subclass
+- Use a strong-referencing id map by default, making it safer for cases
+  with nonstandard or unmanaged object lifetimes
+- Support packing proxies as if they were the original thing in most
+  cases. Nested uses require schema registration. This allows constructing
+  shared buffers out of other shared buffers.
 
 v0.4.8 - 2018-05-28
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Changes
   return a unique object on each access, inflating the resulting buffer
   perhaps considerably. Proper identity was implemented for proxied
   containers though.
+- Shrink some buffers by employing narrow pointers where possible
 
 v0.4.8 - 2018-05-28
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Added
 - More informative packing error messages
 - Add pool module with dynamic object pool implementations, allowing
   incremental build of large object heirarchies/collections.
+- Add GenericFileMapper utility class to get buffers out of files
 
 Changes
 -------
@@ -38,6 +39,11 @@ Changes
 - Support packing proxies as if they were the original thing in most
   cases. Nested uses require schema registration. This allows constructing
   shared buffers out of other shared buffers.
+- Improved idmap handling for the case of repacking proxies. It still may
+  fail to recognize primitive object identity properly since proxies will
+  return a unique object on each access, inflating the resulting buffer
+  perhaps considerably. Proper identity was implemented for proxied
+  containers though.
 
 v0.4.8 - 2018-05-28
 ===================

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -4786,8 +4786,6 @@ class ObjectIdMapper(_CZipMapBase):
         stride0 = cython.size_t, stride1 = cython.size_t,
         indexbuf = 'Py_buffer', pindex = cython.p_char)
     def get(self, key, default = None):
-        if not isinstance(key, basestring):
-            return default
         hkey = _stable_hash(key)
         startpos = self._search_hkey(hkey)
         nitems = self.index_elements

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -123,6 +123,34 @@ class StrongIdMap(object):
         self.strong_refs = {}
         self.objmap = weakref.WeakValueDictionary()
 
+    def __len__(self):
+        return len(self.idmap)
+
+    def __iter__(self):
+        for key in self.idmap:
+            if key in self:
+                yield key
+
+    def iterkeys(self):
+        return iter(self)
+
+    def itervalues(self):
+        for key in self:
+            yield self[key]
+
+    def iteritems(self):
+        for key in self:
+            yield key, self[key]
+
+    def keys(self):
+        return list(self)
+
+    def values(self):
+        return list(self.itervalues())
+
+    def items(self):
+        return list(self.iteritems())
+
     def __setitem__(self, key, value):
         self.idmap[key] = value
         self.objmap[key] = NONE
@@ -256,7 +284,7 @@ class mapped_frozenset(frozenset):
 
 class mapped_tuple(tuple):
     @classmethod
-    @cython.locals(strong_refs = list, widmap = StrongIdMap)
+    @cython.locals(widmap = StrongIdMap)
     def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0,
             array = array.array):
         all_int = 1
@@ -535,7 +563,7 @@ class proxied_dict(object):
         iobuf = BufferIO(buf, offs)
         offs += ObjectIdMapper.build(_enum_keys(obj), iobuf, return_mapper=False)
         packer.pack_into(buf, ipos, iobuf.tell())
-        return proxied_list.pack_into(obj.values(), buf, offs, idmap, implicit_offs)
+        return proxied_list.pack_into([obj[k] for k in obj.iterkeys()], buf, offs, idmap, implicit_offs)
 
     @classmethod
     def unpack_from(cls, buf, offs, idmap = None):

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -283,6 +283,10 @@ class mapped_frozenset(frozenset):
                     PyBuffer_Release(cython.address(pybuf))  # lint:ok
 
 class mapped_tuple(tuple):
+    cython.declare(
+        __weakref__=object,
+    )
+
     @classmethod
     @cython.locals(widmap = StrongIdMap)
     def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0,
@@ -398,6 +402,10 @@ class mapped_tuple(tuple):
         return rv
 
 class mapped_list(list):
+    cython.declare(
+        __weakref__=object,
+    )
+
     @classmethod
     def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0):
         # Same format as tuple, only different base type
@@ -455,6 +463,9 @@ class mapped_list(list):
         return rv
 
 class mapped_dict(dict):
+    cython.declare(
+        __weakref__=object,
+    )
 
     @classmethod
     def pack_into(cls, obj, buf, offs, idmap = None, implicit_offs = 0):
@@ -549,7 +560,11 @@ class proxied_dict(object):
 
     HEADER_PACKER = struct.Struct('=Q')   # Offset into value list.
 
-    cython.declare(objmapper=object, vlist=proxied_list)
+    cython.declare(
+        __weakref__=object,
+        objmapper=object,
+        vlist=proxied_list,
+    )
 
     def __init__(self, objmapper, vlist):
         self.objmapper = objmapper
@@ -821,6 +836,7 @@ def islist(obj):
 class proxied_list(object):
 
     cython.declare(
+        __weakref__ = object,
         buf = object,
         pybuf = 'Py_buffer',
         offs = cython.ulonglong

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -342,7 +342,7 @@ def wrapped_id(obj):
 @cython.inline
 @cython.returns(cython.bint)
 def is_wrapped_key(obj):
-    # singletons and small strings
+    # keys for type-tagged objects
     if isinstance(obj, tuple):
         return len(obj) == 2 and obj[0] is WRAPPED
     elif isinstance(obj, (int, long)):
@@ -352,7 +352,7 @@ def is_wrapped_key(obj):
 @cython.ccall
 @cython.inline
 def get_wrapped_key(obj):
-    # singletons and small strings
+    # the key for the unwrapped value
     if isinstance(obj, tuple):
         return obj[1]
     elif isinstance(obj, (int, long)):

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -535,7 +535,7 @@ class proxied_dict(object):
         iobuf = BufferIO(buf, offs)
         offs += ObjectIdMapper.build(_enum_keys(obj), iobuf, return_mapper=False)
         packer.pack_into(buf, ipos, iobuf.tell())
-        return offs + proxied_list.pack_into(obj.values(), buf, offs, idmap, implicit_offs)
+        return proxied_list.pack_into(obj.values(), buf, offs, idmap, implicit_offs)
 
     @classmethod
     def unpack_from(cls, buf, offs, idmap = None):

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -2942,6 +2942,10 @@ class _CZipMapBase(object):
 class GenericFileMapper(_ZipMapBase):
     @classmethod
     def map_file(cls, fileobj, offset = 0, size = None):
+        """
+        Returns a buffer mapping the file object's requested
+        range, and the underlying mmap object as a tuple.
+        """
         if isinstance(fileobj, zipfile.ZipExtFile):
             return cls.map_zipfile(fileobj, offset, size)
 
@@ -2952,7 +2956,7 @@ class GenericFileMapper(_ZipMapBase):
         map_start = offset - offset % mmap.ALLOCATIONGRANULARITY
         buf = mmap.mmap(fileobj.fileno(), size + offset - map_start,
             access = mmap.ACCESS_READ, offset = map_start)
-        return buffer(buf, offset - map_start)
+        return buffer(buf, offset - map_start), buf
 
 class MappedArrayProxyBase(_ZipMapBase):
     _CURRENT_VERSION = 2

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -1194,7 +1194,7 @@ class proxied_list(object):
             index = self.elem_start + index * self.elem_step
 
             if ((self.elem_step < 0 and (index > self.elem_start or index <= self.elem_end))
-                    or (self.elem_step > 0 and (index >= self.elem_end or index < self.elem_start)):
+                    or (self.elem_step > 0 and (index >= self.elem_end or index < self.elem_start))):
                 raise IndexError(orig_index)
 
         if index < 0:

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -1842,6 +1842,14 @@ class BufferProxyObject(object):
         none_bitmap = cython.ulonglong
     )
 
+    @property
+    def _proxy_buffer(self):
+        return self.buf
+
+    @property
+    def _proxy_offset(self):
+        return self.offs
+
     @cython.locals(offs = cython.ulonglong, none_bitmap = cython.ulonglong)
     def __init__(self, buf, offs, none_bitmap, idmap = None):
         if cython.compiled:

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -2580,8 +2580,11 @@ class Schema(object):
                         except Exception as e:
                             try:
                                 # Add some context. It may not work with all exception types, hence the fallback
-                                e = type(e)("%s packing attribute %s=%r of type %r" % (
-                                    e, slot, val, type(obj).__name__))
+                                vrepr = repr(val)
+                                if len(vrepr) > 200:
+                                    vrepr = vrepr[:200] + '...'
+                                e = type(e)("%s packing attribute %s=%s of type %s" % (
+                                    e, slot, vrepr, type(obj).__name__))
                             except:
                                 pass
                             else:

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -20,7 +20,6 @@ import collections
 import weakref
 from datetime import timedelta, datetime, date
 from decimal import Decimal
-import numpy as np
 
 try:
     from cdecimal import Decimal as cDecimal
@@ -958,7 +957,7 @@ class proxied_ndarray(object):
 
         data = proxied_buffer.unpack_from(buf, offs + data_offs)
 
-        ndarray = np.frombuffer(data, np.dtype(dtype_params))
+        ndarray = numpy.frombuffer(data, numpy.dtype(dtype_params))
         return ndarray.reshape(shape)
 
 # @cython.ccall
@@ -1680,7 +1679,7 @@ class mapped_object(object):
         date : 'V',
         Decimal : 'F',
         cDecimal : 'F',
-        np.ndarray : 'n',
+        numpy.ndarray : 'n',
         buffer : 'r',
 
         dict : 'm',
@@ -1826,7 +1825,7 @@ VARIABLE_TYPES = {
     date : mapped_date,
     Decimal : mapped_decimal,
     cDecimal : mapped_decimal,
-    np.ndarray : proxied_ndarray,
+    numpy.ndarray : proxied_ndarray,
     buffer : proxied_buffer,
 }
 
@@ -2323,7 +2322,7 @@ PROXY_TYPES = {
     date : DateBufferProxyProperty,
     Decimal : DecimalBufferProxyProperty,
     cDecimal : DecimalBufferProxyProperty,
-    np.ndarray : ProxiedNDArrayBufferProxyProperty,
+    numpy.ndarray : ProxiedNDArrayBufferProxyProperty,
     buffer : ProxiedBufferBufferProxyProperty,
 }
 

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -231,6 +231,7 @@ class StrongIdMap(object):
     def clear_preloaded(self):
         self.preloaded.clear()
 
+    @cython.ccall
     def get(self, key, default=None):
         if key in self.preloaded:
             return self.preloaded[key]
@@ -2681,7 +2682,11 @@ class Schema(object):
                         val_id = wrapped_id(val)
                     else:
                         val_id = shared_id(val)
-                    val_offs = idmap_get(val_id)
+                    if widmap is not None:
+                        # fast-call
+                        val_offs = widmap.get(val_id)
+                    else:
+                        val_offs = idmap_get(val_id)
                     if val_offs is None:
                         idmap[val_id] = ival_offs = offs + implicit_offs
                         if widmap is not None:

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -302,7 +302,13 @@ def shared_id(obj):
     # (id(buf), offs) of buffer-mapped proxies
     if isinstance(obj, proxied_list):
         lobj = obj
-        return (id(lobj.buf) << 64) | lobj.offs
+        rv = (id(lobj.buf) << 64) | lobj.offs
+        if lobj.elem_step != 0:
+            # Add slice arguments to the shared_id
+            rv |= long(lobj.elem_step) << (68 + 64)
+            rv |= long(lobj.elem_start) << (68 + 128)
+            rv |= long(lobj.elem_end) << (68 + 192)
+        return rv
     elif isinstance(obj, proxied_dict):
         dobj = obj
         return (id(dobj.buf) << 64) | dobj.offs

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -2645,14 +2645,18 @@ class Schema(object):
                 if fixed_present & mask:
                     packable_append(val)
                 else:
-                    val_id = shared_id(val)
+                    slot_type = slot_types[slot]
+                    if slot_type is mapped_object:
+                        val_id = wrapped_id(val)
+                    else:
+                        val_id = shared_id(val)
                     val_offs = idmap_get(val_id)
                     if val_offs is None:
                         idmap[val_id] = ival_offs = offs + implicit_offs
                         if widmap is not None:
                             widmap.link(val_id, val)
                         try:
-                            offs = slot_types[slot].pack_into(val, buf, offs, idmap, implicit_offs)
+                            offs = slot_type.pack_into(val, buf, offs, idmap, implicit_offs)
                         except Exception as e:
                             try:
                                 # Add some context. It may not work with all exception types, hence the fallback

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -654,7 +654,10 @@ def _stable_hash(key):
     elif isinstance(key, basestring):
         hval = xxhash.xxh64(safe_utf8(key)).intdigest()
     elif isinstance(key, (int, long)):
-        hval = key
+        try:
+            hval = key
+        except OverflowError:
+            hval = key & 0xFFFFFFFFFFFFFFFF
     elif isinstance(key, float):
         trunc_key = int(key)
         if trunc_key == key:

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -1193,8 +1193,8 @@ class proxied_list(object):
 
             index = self.elem_start + index * self.elem_step
 
-            if (self.elem_step < 0 and (index > self.elem_start or index <= self.elem_end)) or (
-                self.elem_step > 0 and (index >= self.elem_end or index < self.elem_start)):
+            if ((self.elem_step < 0 and (index > self.elem_start or index <= self.elem_end))
+                    or (self.elem_step > 0 and (index >= self.elem_end or index < self.elem_start)):
                 raise IndexError(orig_index)
 
         if index < 0:

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -98,7 +98,7 @@ class BaseObjectPool(object):
         else:
             section = self.add_section()
             pos = self._pack_into(schema, obj, section)
-        return schema.unpack_from(section.real_buf, pos)
+        return pos, schema.unpack_from(section.real_buf, pos)
 
     def clear_idmaps(self):
         for section in self.sections:

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -100,6 +100,17 @@ class BaseObjectPool(object):
             pos = self._pack_into(schema, obj, section)
         return pos + section.implicit_offs, schema.unpack_from(section.real_buf, pos)
 
+    def find_section(self, pos):
+        for section in self.sections:
+            if section.implicit_offs <= pos < section.implicit_offs + len(section.buf):
+                return section
+
+    def unpack(self, schema, pos):
+        section = self.find_section(pos)
+        if section is None:
+            raise IndexError("Position %d out of bounds for object pool" % pos)
+        return schema.unpack_from(section.real_buf, pos - section.implicit_offs)
+
     def clear_idmaps(self):
         for section in self.sections:
             self.idmap.clear()

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -172,4 +172,4 @@ class BaseObjectPool(object):
 class TemporaryObjectPool(BaseObjectPool):
 
     def _mktemp(self):
-        return tempfile.NamedTemporaryFile(**self.temp_kwargs)
+        return tempfile.TemporaryFile(**self.temp_kwargs)

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -83,7 +83,7 @@ class BaseObjectPool(object):
             min_pack_buffer_cell[0] = max(min_pack_buffer_cell[0], len(buf))
         return section.append(buf, write_pos)
 
-    def pack(self, schema, obj, min_pack_buffer=DEFAULT_PACK_BUFFER):
+    def pack(self, schema, obj, min_pack_buffer=DEFAULT_PACK_BUFFER, clear_idmaps_on_new_section=True):
         sections = self.sections
         _min_pack_buffer=[min_pack_buffer]
         for i in xrange(self.freehead, len(sections)):
@@ -98,6 +98,8 @@ class BaseObjectPool(object):
             else:
                 break
         else:
+            if clear_idmaps_on_new_section:
+                self.clear_idmaps()
             section = self.add_section()
             pos = self._pack_into(schema, obj, section)
         return pos + section.implicit_offs, schema.unpack_from(section.real_buf, pos)
@@ -115,7 +117,7 @@ class BaseObjectPool(object):
 
     def clear_idmaps(self):
         for section in self.sections:
-            self.idmap.clear()
+            section.idmap.clear()
 
 class TemporaryObjectPool(BaseObjectPool):
 

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -5,6 +5,8 @@ import tempfile
 import mmap
 import struct
 
+from .mapped_struct import StrongIdMap
+
 # Default section size is set to 128MB which is a size at which most
 # malloc implementations turn to mmap
 DEFAULT_SECTION_SIZE = 128<<20
@@ -18,7 +20,7 @@ class Section(object):
         self.real_buf = buffer(buf)
         self.implicit_offs = implicit_offs
         self.write_pos = 0
-        self.idmap = {}
+        self.idmap = StrongIdMap()
 
     def allocate(self, size=None):
         write_pos = self.write_pos

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -63,6 +63,14 @@ class BaseObjectPool(object):
         self.total_size = 0
         self.idmap_preload = []
 
+    @property
+    def size(self):
+        if self.sections:
+            last_section = self.sections[-1]
+            return last_section.implicit_offs + last_section.write_pos
+        else:
+            return 0
+
     def add_section(self):
         f = self._mktemp()
         try:

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -96,7 +96,7 @@ class BaseObjectPool(object):
         write_pos = section.write_pos
         if idmap is None:
             idmap = section.idmap
-        buf = schema.pack(obj, section.idmap, implicit_offs=section.implicit_offs + write_pos)
+        buf = schema.pack(obj, idmap, implicit_offs=section.implicit_offs + write_pos)
         if min_pack_buffer_cell:
             min_pack_buffer_cell[0] = max(min_pack_buffer_cell[0], len(buf))
         return section.append(buf, write_pos)
@@ -164,4 +164,4 @@ class BaseObjectPool(object):
 class TemporaryObjectPool(BaseObjectPool):
 
     def _mktemp(self):
-        return tempfile.TemporaryFile(**self.temp_kwargs)
+        return tempfile.NamedTemporaryFile(**self.temp_kwargs)

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import tempfile
+import mmap
+import struct
+
+# Default section size is set to 128MB which is a size at which most
+# malloc implementations turn to mmap
+DEFAULT_SECTION_SIZE = 128<<20
+
+DEFAULT_PACK_BUFFER = 65536
+
+class Section(object):
+
+    def __init__(self, buf, implicit_offs=0):
+        self.buf = buf
+        self.real_buf = buffer(buf)
+        self.implicit_offs = implicit_offs
+        self.write_pos = 0
+        self.idmap = {}
+
+    def allocate(self, size=None):
+        write_pos = self.write_pos
+        if size is None:
+            size = len(self.buf) - write_pos
+        if (write_pos + size) <= len(self.buf):
+            self.write_pos += size
+            return write_pos
+        else:
+            raise IndexError("Buffer overflow trying to allocate %d bytes from section" % size)
+
+    def resize(self, pos, new_size):
+        new_end = pos + new_size
+        if new_end != self.write_pos:
+            raise RuntimeError("Cannot resize non-tail buffers")
+        self.write_pos = new_end
+
+    def append(self, buf, verify_pos=None):
+        write_pos = self.allocate(len(buf))
+        if verify_pos is not None and verify_pos != write_pos:
+            raise RuntimeError("Concurrent modification")
+        self.buf[write_pos:write_pos+len(buf)] = bytes(buf)
+        return write_pos
+
+    @property
+    def free_space(self):
+        return len(self.buf) - self.write_pos
+
+class BaseObjectPool(object):
+
+    def _mktemp(self):
+        raise NotImplementedError
+
+    def __init__(self, section_size=DEFAULT_SECTION_SIZE, temp_kwargs={}):
+        self.temp_kwargs = temp_kwargs
+        self.section_size = section_size
+        self.sections = []
+        self.freehead = 0
+        self.total_size = 0
+
+    def add_section(self):
+        with self._mktemp() as f:
+            f.truncate(self.section_size)
+            buf = mmap.mmap(
+                f.fileno(), 0,
+                flags = mmap.MAP_SHARED,
+                prot = mmap.PROT_READ|mmap.PROT_WRITE,
+                access = mmap.ACCESS_READ|mmap.ACCESS_WRITE)
+
+        implicit_offs = self.total_size
+        self.total_size += len(buf)
+        new_section = Section(buf, implicit_offs)
+        self.sections.append(new_section)
+        return new_section
+
+    def _pack_into(self, schema, obj, section, min_pack_buffer_cell=None):
+        write_pos = section.write_pos
+        buf = schema.pack(obj, implicit_offs=section.implicit_offs + write_pos)
+        if min_pack_buffer_cell:
+            min_pack_buffer_cell[0] = max(min_pack_buffer_cell[0], len(buf))
+        return section.append(buf, write_pos)
+
+    def pack(self, schema, obj, min_pack_buffer=DEFAULT_PACK_BUFFER):
+        sections = self.sections
+        _min_pack_buffer=[min_pack_buffer]
+        for i in xrange(self.freehead, len(sections)):
+            section = sections[i]
+            if section.free_space < _min_pack_buffer[0]:
+                continue
+
+            try:
+                pos = self._pack_into(schema, obj, section, _min_pack_buffer)
+            except (struct.error, IndexError):
+                pass
+            else:
+                break
+        else:
+            section = self.add_section()
+            pos = self._pack_into(schema, obj, section)
+        return schema.unpack_from(section.real_buf, pos)
+
+    def clear_idmaps(self):
+        for section in self.sections:
+            self.idmap.clear()
+
+class TemporaryObjectPool(BaseObjectPool):
+
+    def _mktemp(self):
+        return tempfile.TemporaryFile(**self.temp_kwargs)

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -78,7 +78,7 @@ class BaseObjectPool(object):
 
     def _pack_into(self, schema, obj, section, min_pack_buffer_cell=None):
         write_pos = section.write_pos
-        buf = schema.pack(obj, implicit_offs=section.implicit_offs + write_pos)
+        buf = schema.pack(obj, section.idmap, implicit_offs=section.implicit_offs + write_pos)
         if min_pack_buffer_cell:
             min_pack_buffer_cell[0] = max(min_pack_buffer_cell[0], len(buf))
         return section.append(buf, write_pos)

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -32,12 +32,6 @@ class Section(object):
         else:
             raise IndexError("Buffer overflow trying to allocate %d bytes from section" % size)
 
-    def resize(self, pos, new_size):
-        new_end = pos + new_size
-        if new_end != self.write_pos:
-            raise RuntimeError("Cannot resize non-tail buffers")
-        self.write_pos = new_end
-
     def append(self, buf, verify_pos=None):
         write_pos = self.allocate(len(buf))
         if verify_pos is not None and verify_pos != write_pos:
@@ -193,7 +187,6 @@ class BaseObjectPool(object):
             return 0
 
         for section in self.sections[:-1]:
-            write_bytes = len(section.real_buf)
             fileobj.write(section.real_buf)
         section = self.sections[-1]
 

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -98,7 +98,7 @@ class BaseObjectPool(object):
         else:
             section = self.add_section()
             pos = self._pack_into(schema, obj, section)
-        return pos, schema.unpack_from(section.real_buf, pos)
+        return pos + section.implicit_offs, schema.unpack_from(section.real_buf, pos)
 
     def clear_idmaps(self):
         for section in self.sections:

--- a/sharedbuffers/pool.py
+++ b/sharedbuffers/pool.py
@@ -135,7 +135,7 @@ class BaseObjectPool(object):
         Make sure the contents of buf are relocatable (ie: have no external references)
         """
         sections = self.sections
-        for section in reversed(sections):
+        for section in sections:
             if section.free_space < len(buf):
                 continue
 

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -781,6 +781,32 @@ class IdMapperTest(unittest.TestCase):
             if rvv != v:
                 self.assertEquals(rvv, v)
 
+    def testBuildInMem(self):
+        self._testBuild(2010, None)
+
+    def testBuildInMemReversed(self):
+        self._testBuild(2010, None, reversed = True)
+
+    def testBuildInMemShuffled(self):
+        self._testBuild(2010, None, shuffled = True)
+
+    def testBuildInMemDiscardDuplicates(self):
+        self._testBuild(2010, None, build_kwargs = dict(discard_duplicates = True),
+            gen_dupes = True)
+
+    def testBuildOnDisk(self):
+        self._testBuild(1010, tempfile.gettempdir())
+
+    def testBuildOnDiskReversed(self):
+        self._testBuild(1010, tempfile.gettempdir(), reversed=True)
+
+    def testBuildOnDiskShuffled(self):
+        self._testBuild(1010, tempfile.gettempdir(), shuffled=True)
+
+    def testBuildOnDiskDiscardDuplicates(self):
+        self._testBuild(1010, tempfile.gettempdir(), build_kwargs = dict(discard_duplicates = True),
+            gen_dupes = True)
+
     @unittest.skipIf(SKIP_HUGE, 'SKIP_HUGE is set')
     def testBuildHugeInMem(self):
         self._testBuild(2010530, None)
@@ -817,6 +843,22 @@ class IdMapperTest(unittest.TestCase):
 
 class Id32MapperTest(IdMapperTest):
     IdMapperClass = mapped_struct.NumericId32Mapper
+
+class ObjectIdMapperTest(IdMapperTest):
+    IdMapperClass = mapped_struct.ObjectIdMapper
+
+    def gen_values(self, *p, **kw):
+        str_ = str
+        for k, v in super(ObjectIdMapperTest, self).gen_values(*p, **kw):
+            yield k, v
+            yield str_(k), v
+            yield (k,), v
+
+    # Not supported by ObjectIdMapper
+    testBuildInMemDiscardDuplicates = None
+    testBuildOnDiskDiscardDuplicates = None
+    testBuildHugeInMemDiscardDuplicates = None
+    testBuildHugeOnDiskDiscardDuplicates = None
 
 class ApproxStringIdMultiMapperTest(IdMapperTest):
     IdMapperClass = mapped_struct.ApproxStringIdMultiMapper

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -795,16 +795,16 @@ class IdMapperTest(unittest.TestCase):
             gen_dupes = True)
 
     def testBuildOnDisk(self):
-        self._testBuild(1010, tempfile.gettempdir())
+        self._testBuild(10107, tempfile.gettempdir())
 
     def testBuildOnDiskReversed(self):
-        self._testBuild(1010, tempfile.gettempdir(), reversed=True)
+        self._testBuild(10107, tempfile.gettempdir(), reversed=True)
 
     def testBuildOnDiskShuffled(self):
-        self._testBuild(1010, tempfile.gettempdir(), shuffled=True)
+        self._testBuild(10107, tempfile.gettempdir(), shuffled=True)
 
     def testBuildOnDiskDiscardDuplicates(self):
-        self._testBuild(1010, tempfile.gettempdir(), build_kwargs = dict(discard_duplicates = True),
+        self._testBuild(10107, tempfile.gettempdir(), build_kwargs = dict(discard_duplicates = True),
             gen_dupes = True)
 
     @unittest.skipIf(SKIP_HUGE, 'SKIP_HUGE is set')
@@ -859,6 +859,11 @@ class ObjectIdMapperTest(IdMapperTest):
     testBuildOnDiskDiscardDuplicates = None
     testBuildHugeInMemDiscardDuplicates = None
     testBuildHugeOnDiskDiscardDuplicates = None
+
+    # Too much memory
+    testBuildHugeOnDisk = None
+    testBuildHugeOnDiskReversed = None
+    testBuildHugeOnDiskShuffled = None
 
 class ApproxStringIdMultiMapperTest(IdMapperTest):
     IdMapperClass = mapped_struct.ApproxStringIdMultiMapper

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -1625,7 +1625,8 @@ class DictPackingCommonTest(object):
 
         d = {
             'a': SimpleStruct(a=1, b=2.0),
-            'b': SimpleStruct(a=2, b=None)
+            'b': SimpleStruct(a=2, b=None),
+            None: SimpleStruct(a=3, b=1.0),
         }
         c = self.pack(d)
 
@@ -1666,6 +1667,7 @@ class MappedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, Dic
         {1.0: 10.0, 2.0: 2.2, 3.0: 3.3},
         {frozenset([1]): frozenset(['a']), frozenset([2]): frozenset(['b'])},
         {'a': 1, 1: 'a', frozenset(): 1.0, (1, 2): 80000 },
+        {None: 3},
     ]
 
 class ProxiedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, DictPackingCommonTest):
@@ -1679,7 +1681,8 @@ class ProxiedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, Di
         {'a': frozenset(), 'b': (1, 2), 'c': 1.0, 'd': [1, 2], 'e': dict(a=1) },
         {0: 42, 'a1_@!': 69, 3.5: 'uhhhh', (1, 2, 3): "four-five-six"},
         {frozenset([1, 2]) : 97.9},
-        {1.0: "test floats equivalent to integers"}
+        {1.0: "test floats equivalent to integers"},
+        {None: 3},
     ]
 
 class MappedDatetimePackingTest(unittest.TestCase):

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -153,6 +153,8 @@ class NDArrayStruct(TestStruct):
 
 class ObjectStruct(TestStruct):
     __slot_types__ = {
+        'b' : bytes,
+        'q' : bytes,
         'o' : object,
     }
 
@@ -278,6 +280,21 @@ class BasePackingTestMixin(object):
                 self.assertTrue(hasattr(dx, k))
                 self.assertEqual(getattr(dx, k), v)
             for k in self.Struct.__slots__:
+                if k not in TEST_VALUES:
+                    self.assertFalse(hasattr(dx, k))
+
+    def testPackUnpackIdmap(self):
+        for TEST_VALUES in self.TEST_VALUES:
+            x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
+            pack_idmap = {}
+            unpack_idmap = {}
+            dx = self.schema.unpack(self.schema.pack(x, pack_idmap), unpack_idmap)
+            for k,v in TEST_VALUES.iteritems():
+                unpack_idmap.clear()
+                self.assertTrue(hasattr(dx, k))
+                self.assertEqual(getattr(dx, k), v)
+            for k in self.Struct.__slots__:
+                unpack_idmap.clear()
                 if k not in TEST_VALUES:
                     self.assertFalse(hasattr(dx, k))
 
@@ -484,7 +501,10 @@ class ObjectPackagingTest(SimplePackingTest):
         { 'o' : u"bláblá€" },
         { 'o' : datetime.now() },
         { 'o' : date.today() },
-        { 'o' : buffer(bytearray(xrange(100)))}
+        { 'o' : buffer(bytearray(xrange(100)))},
+        { 'b' : "blabla", 'o' : "blabla" },
+        { 'q' : "blabla", 'o' : "blabla" },
+        { 'b' : "blabla", 'o' : "blabla", 'q' : "blabla" },
     ]
 
 class ObjectNDArrayPackagingTest(SimplePackingTest):

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -1740,6 +1740,8 @@ class MappedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, Dic
         {frozenset([1]): frozenset(['a']), frozenset([2]): frozenset(['b'])},
         {'a': 1, 1: 'a', frozenset(): 1.0, (1, 2): 80000 },
         {None: 3},
+        {(1,2,3): 4, (-1,3): 7},
+        {frozenset([1,2,3]): 4, frozenset([-1,3]): 7},
     ]
 
 class ProxiedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, DictPackingCommonTest):
@@ -1755,6 +1757,8 @@ class ProxiedDictPackingTest(unittest.TestCase, CollectionPackingTestHelpers, Di
         {frozenset([1, 2]) : 97.9},
         {1.0: "test floats equivalent to integers"},
         {None: 3},
+        {(1,2,3): 4, (-1,3): 7},
+        {frozenset([1,2,3]): 4, frozenset([-1,3]): 7},
     ]
 
 class MappedDatetimePackingTest(unittest.TestCase):

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -1674,6 +1674,7 @@ class DictPackingCommonTest(object):
             'a': SimpleStruct(a=1, b=2.0),
             'b': SimpleStruct(a=2, b=None),
             None: SimpleStruct(a=3, b=1.0),
+            (): SimpleStruct(a=4, b=1.5),
         }
         c = self.pack(d)
 
@@ -1681,6 +1682,10 @@ class DictPackingCommonTest(object):
         self.assertEquals(c['a'].b, 2.0)
         self.assertEquals(c['b'].a, 2)
         self.assertEquals(c['b'].b, None)
+        self.assertEquals(c[None].a, 3)
+        self.assertEquals(c[None].b, 1.0)
+        self.assertEquals(c[()].a, 4)
+        self.assertEquals(c[()].b, 1.5)
 
     def testMappedDictKeys(self):
         for d in self.TEST_DICTS:

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -281,6 +281,25 @@ class BasePackingTestMixin(object):
                 if k not in TEST_VALUES:
                     self.assertFalse(hasattr(dx, k))
 
+    def testPackMultiple(self):
+        for TEST_VALUES in self.TEST_VALUES:
+            x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
+
+            buf = bytearray(16<<20)
+            offsets = []
+            endp = 0
+            for i in xrange(10):
+                offsets.append(endp)
+                endp = self.schema.pack_into(x, buf, endp)
+            for offs in offsets:
+                dx = self.schema.unpack_from(buf, offs)
+                for k,v in TEST_VALUES.iteritems():
+                    self.assertTrue(hasattr(dx, k))
+                    self.assertEqual(getattr(dx, k), v)
+                for k in self.Struct.__slots__:
+                    if k not in TEST_VALUES:
+                        self.assertFalse(hasattr(dx, k))
+
     def testPackPickleUnpack(self):
         for TEST_VALUES in self.TEST_VALUES:
             x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
@@ -440,6 +459,16 @@ class NestedContainerPackingTest(SimplePackingTest):
         'l' : [[1],[2,3],(3,4)],
         'pt' : ((3,),(6,7,8),(1,7)),
         'pl' : [[1],[2,3],(3,4)],
+    }]
+
+class DictContainerPackingTest(SimplePackingTest):
+    Struct = ContainerStruct
+    TEST_VALUES = [{
+        'fset' : frozenset([1,3,7]),
+        't' : ({'a':frozenset([1,3,4])},{'b':(1,3,4)},{'c':[1,3,4]}),
+        'l' : [{'a':frozenset([1,3,4])},{'b':(1,3,4)},{'c':[1,3,4]}],
+        'pt' : ({'a':frozenset([1,3,4])},{'b':(1,3,4)},{'c':[1,3,4]}),
+        'pl' : [{'a':frozenset([1,3,4])},{'b':(1,3,4)},{'c':[1,3,4]}],
     }]
 
 class ObjectPackagingTest(SimplePackingTest):

--- a/tests/pool.py
+++ b/tests/pool.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import unittest
+from .mapped_struct import TestStruct
+
+from sharedbuffers import mapped_struct, pool
+
+class ContainerStruct(TestStruct):
+    __slot_types__ = {
+        'a' : int,
+        'b' : float,
+        'fset' : frozenset,
+        't' : tuple,
+        'l' : list,
+        'pt' : mapped_struct.proxied_tuple,
+        'pl' : mapped_struct.proxied_list,
+        'o' : object
+    }
+
+class SmallIntContainerPackingTest(unittest.TestCase):
+    Struct = ContainerStruct
+    TEST_VALUES = [{
+        'a' : 20,
+        'b' : 3.24,
+        'fset' : frozenset([1,3,7]),
+        't' : (3,6,7),
+        'l' : [1,2,3],
+        'pt' : (3,6,7),
+        'pl' : [1,2,3],
+        'o' : [{"a": (3,4,5), "b": frozenset([1000,3444,525])}],
+    }]
+
+    def setUp(self):
+        self.schema = mapped_struct.Schema.from_typed_slots(self.Struct)
+
+    def testPack(self):
+        p = pool.TemporaryObjectPool()
+        for TEST_VALUES in self.TEST_VALUES:
+            x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
+            dx = p.pack(self.schema, x)
+            for k,v in TEST_VALUES.iteritems():
+                self.assertTrue(hasattr(dx, k))
+                self.assertEqual(getattr(dx, k), v)
+            for k in self.Struct.__slots__:
+                if k not in TEST_VALUES:
+                    self.assertFalse(hasattr(dx, k))

--- a/tests/pool.py
+++ b/tests/pool.py
@@ -46,6 +46,20 @@ class SmallIntContainerPackingTest(unittest.TestCase):
                 if k not in TEST_VALUES:
                     self.assertFalse(hasattr(dx, k))
 
+    def testPreload(self):
+        p = pool.TemporaryObjectPool()
+        for TEST_VALUES in self.TEST_VALUES:
+            x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
+            p.add_preload(self.schema, x)
+        for TEST_VALUES in self.TEST_VALUES:
+            dx = p.pack(self.schema, x)[1]
+            for k,v in TEST_VALUES.iteritems():
+                self.assertTrue(hasattr(dx, k))
+                self.assertEqual(getattr(dx, k), v)
+            for k in self.Struct.__slots__:
+                if k not in TEST_VALUES:
+                    self.assertFalse(hasattr(dx, k))
+
     def testOverflow(self):
         p = pool.TemporaryObjectPool(section_size=4096)
         for i in xrange(300):

--- a/tests/pool.py
+++ b/tests/pool.py
@@ -38,7 +38,7 @@ class SmallIntContainerPackingTest(unittest.TestCase):
         p = pool.TemporaryObjectPool()
         for TEST_VALUES in self.TEST_VALUES:
             x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
-            dx = p.pack(self.schema, x)
+            dx = p.pack(self.schema, x)[1]
             for k,v in TEST_VALUES.iteritems():
                 self.assertTrue(hasattr(dx, k))
                 self.assertEqual(getattr(dx, k), v)
@@ -51,7 +51,7 @@ class SmallIntContainerPackingTest(unittest.TestCase):
         for i in xrange(300):
             for TEST_VALUES in self.TEST_VALUES:
                 x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
-                dx = p.pack(self.schema, x)
+                dx = p.pack(self.schema, x)[1]
                 for k,v in TEST_VALUES.iteritems():
                     self.assertTrue(hasattr(dx, k))
                     self.assertEqual(getattr(dx, k), v)

--- a/tests/pool.py
+++ b/tests/pool.py
@@ -59,3 +59,16 @@ class SmallIntContainerPackingTest(unittest.TestCase):
                     if k not in TEST_VALUES:
                         self.assertFalse(hasattr(dx, k))
         self.assertGreater(len(p.sections), 1)
+
+    def testUnpack(self):
+        p = pool.TemporaryObjectPool()
+        for TEST_VALUES in self.TEST_VALUES:
+            x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
+            pos = p.pack(self.schema, x)[0]
+            dx = p.unpack(self.schema, pos)
+            for k,v in TEST_VALUES.iteritems():
+                self.assertTrue(hasattr(dx, k))
+                self.assertEqual(getattr(dx, k), v)
+            for k in self.Struct.__slots__:
+                if k not in TEST_VALUES:
+                    self.assertFalse(hasattr(dx, k))

--- a/tests/pool.py
+++ b/tests/pool.py
@@ -45,3 +45,17 @@ class SmallIntContainerPackingTest(unittest.TestCase):
             for k in self.Struct.__slots__:
                 if k not in TEST_VALUES:
                     self.assertFalse(hasattr(dx, k))
+
+    def testOverflow(self):
+        p = pool.TemporaryObjectPool(section_size=4096)
+        for i in xrange(300):
+            for TEST_VALUES in self.TEST_VALUES:
+                x = self.Struct(**{k:v for k,v in TEST_VALUES.iteritems()})
+                dx = p.pack(self.schema, x)
+                for k,v in TEST_VALUES.iteritems():
+                    self.assertTrue(hasattr(dx, k))
+                    self.assertEqual(getattr(dx, k), v)
+                for k in self.Struct.__slots__:
+                    if k not in TEST_VALUES:
+                        self.assertFalse(hasattr(dx, k))
+        self.assertGreater(len(p.sections), 1)


### PR DESCRIPTION
This PR implements a bunch of machinery needed to incrementally construct large fully-connected object graphs.

The problem with fully connected object graphs is that they can't be constructed with the current API without holding them fully in memory. If they're big enough, that can be prohibitive.

This PR allows one to construct proxies into a dynamically growing staging area, replacing in-memory data structures with memory-mapped proxies. This releases some memory pressure by allowing the proxies to take the place of memory-intensive objects within the object graph. Finally, the contents of the dynamic buffers can be dumped together with any remaining objects by proper manipulation of id maps.

To make all this truly work, a lot of changes to the id mapping mechanism had to be introduced. An id map class that automatically discards transient objects was introduced. This is used as the default id map when constructing shared buffers now, since it's far safer than the old default. It's less efficient at object deduplication, however. To gain the old efficiency a set of "stable" objects (ones that we know are going to have a unique id for the duration of the packing procedure) can be specified when constructing the id map.

Furthermore, the id map structure was turned a bit more into a white box by exposing a pair of functions to construct ids: `shared_id` and `wrapped_id`. They can be used to pre-populate id maps with manually packed objects.

Additionally, the derivation of identity keys was changed to accomodate proxies in lieu of actual classes. Now proxy classes use their buffer-offset as identity key, whereas commonly used constants use their value, allowing automatic deduplication of commonly occurring primitive values across the board.

Some bugs in the existing id mapping code were fixed as well as fixes to some collections, like the ObjectIdMapper, that arose during testing.
