### PR TITLE
Fix buffer leak in proxies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ Changes
 - Use `v` prefix on releases to have fixed links for this document
 - mapped_list now returns actual lists and not a subclass
 
+Bugfixes
+--------
+
+- Fix a buffer reference leak in proxies when building with Cython
+
 v0.4.8 - 2018-05-28
 ===================
 


### PR DESCRIPTION
Cython doesn't invoke __del__ on extension types. Also,
Py_buffer should be initialized in cinit.