### PR TITLE
Fix frozenset bitmap packing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ The format is largely inspired by keepachangelog_.
 
 .. _0.1.1:
 
+0.4.9 - 2018-10-29
+==================
+
+Bugfixes
+--------
+
+- Fix frozenset bitmap packing, it would write past the allocated
+  bitmap and thus not only clobber memory after the marked end,
+  but also discard elements in the process
+
 0.4.8 - 2018-05-28
 ==================
 

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -83,7 +83,7 @@ class mapped_frozenset(frozenset):
         if all_int:
             maxval = max(obj) if obj else 0
             minval = min(obj) if obj else 0
-            if 0 <= minval and maxval < 120:
+            if 0 <= minval and maxval < 56:
                 # inline bitmap
                 buf[offs] = 'm'
                 buf[offs+1:offs+8] = '\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -260,6 +260,9 @@ class mapped_list(list):
 
         baseoffs = offs
         dcode = buf[offs]
+        if type(dcode) is int:
+            # bytearrays...
+            dcode = chr(dcode)
         if dcode in ('B','b','H','h','I','i'):
             dtype = dcode
             objlen, = struct.unpack('<I', buf[offs+1:offs+4] + '\x00')

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -1117,3 +1117,16 @@ class FrozensetPackingTest(unittest.TestCase):
         fs = frozenset()
         mapped_struct.mapped_frozenset.pack_into(fs, a, 0)
         self.assertIs(mapped_struct.mapped_frozenset.unpack_from(a, 0), fs)
+
+    def testBitmapSets(self):
+        a = bytearray(16)
+        bitmap_values = [
+            frozenset([1,3,6]),
+            frozenset([10,30,60]),
+            frozenset([69,99]),
+            frozenset([1,5,7,38,49,67,99,105,119]),
+            frozenset([119]),
+        ]
+        for fs in bitmap_values:
+            mapped_struct.mapped_frozenset.pack_into(fs, a, 0)
+            self.assertEqual(mapped_struct.mapped_frozenset.unpack_from(a, 0), fs)


### PR DESCRIPTION
It would write past the allocated
bitmap and thus not only clobber memory after the marked end,
but also discard elements in the process