### PR TITLE
Avoid python longs if possible

### DIFF
--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -2558,8 +2558,12 @@ class ULongBufferProxyProperty(BaseBufferProxyProperty):
             return None
         if cython.compiled:
             assert (obj.offs + self.offs + cython.sizeof(cython.ulong)) <= obj.pybuf.len  # lint:ok
-            return cython.cast(cython.p_ulonglong,
+            rv = cython.cast(cython.p_ulonglong,
                 cython.cast(cython.p_uchar, obj.pybuf.buf) + obj.offs + self.offs)[0]  # lint:ok
+            if rv < cython.cast(cython.ulonglong, 0x7FFFFFFFFFFFFFFF):
+                return cython.cast(cython.longlong, rv)
+            else:
+                return rv
         else:
             return struct.unpack_from('Q', obj.buf, obj.offs + self.offs)[0]
 

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -2560,7 +2560,7 @@ class ULongBufferProxyProperty(BaseBufferProxyProperty):
             assert (obj.offs + self.offs + cython.sizeof(cython.ulong)) <= obj.pybuf.len  # lint:ok
             rv = cython.cast(cython.p_ulonglong,
                 cython.cast(cython.p_uchar, obj.pybuf.buf) + obj.offs + self.offs)[0]  # lint:ok
-            if rv < cython.cast(cython.ulonglong, 0x7FFFFFFFFFFFFFFF):
+            if rv <= cython.cast(cython.ulonglong, 0x7FFFFFFFFFFFFFFF):
                 return cython.cast(cython.longlong, rv)
             else:
                 return rv


### PR DESCRIPTION
Cython always casts ulonglong into a python long, even when an int would suffice.