### PR TITLE
Implement atomic transactions

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -16,6 +16,8 @@ Added
 - Allow writing to numeric proxy properties when the mapping
   was specified as read-write.
 
+- Allow atomic transactions for numeric proxy properties.
+
 v0.6.4 - 2019-05-30
 ===================
 

--- a/sharedbuffers/mapped_struct.pxd
+++ b/sharedbuffers/mapped_struct.pxd
@@ -86,14 +86,12 @@ cdef inline void _c_atomic_add(atomic_type *ptr, atomic_type value):
 # aliasing issues. Good thing Python is compiled with -fno-strict-aliasing ;)
 
 cdef inline bint _c_atomic_cas_flt(float *ptr, float exp_val, float new_val):
-    cdef int *exp_ptr = <int *>&exp_val
-    cdef int *new_ptr = <int *>&new_val
-    return __sync_bool_compare_and_swap(<int *>ptr, exp_ptr[0], new_ptr[0])
+    return __sync_bool_compare_and_swap(<int *>ptr,
+        (<int *>&exp_val)[0], (<int *>&new_val)[0])
 
 cdef inline bint _c_atomic_cas_dbl(double *ptr, double exp_val, double new_val):
-    cdef long long *exp_ptr = <long long *>&exp_val
-    cdef long long *new_ptr = <long long *>&new_val
-    return __sync_bool_compare_and_swap(<long long *>ptr, exp_ptr[0], new_ptr[0])
+    return __sync_bool_compare_and_swap(<long long *>ptr,
+        (<long long *>&exp_val)[0], (<long long *>&new_val)[0])
 
 cdef inline void _c_atomic_add_flt(float *ptr, float value):
     cdef float tmp

--- a/sharedbuffers/mapped_struct.pxd
+++ b/sharedbuffers/mapped_struct.pxd
@@ -53,9 +53,40 @@ cpdef unsigned long long _stable_hash(key) except? 0
 cdef extern from *:
     cdef int __builtin_popcountll(unsigned long long x)
     cdef void __sync_synchronize()
+    cdef bint __sync_bool_compare_and_swap(void *ptr, ...)
 
 cdef inline int popcount(unsigned long long x):
     return __builtin_popcountll(x)
 
 cdef inline void mfence_full():
     __sync_synchronize()
+
+# NOTE: This is not the same as the fused type 'numeric', because CAS
+# doesn't work with floating point types.
+ctypedef fused atomic_type:
+    char
+    unsigned char
+    short
+    unsigned short
+    int
+    unsigned int
+    long
+    unsigned long
+    long long
+    unsigned long long
+
+cdef inline bint _c_atomic_cas(atomic_type *ptr, atomic_type exp_val, atomic_type new_val):
+    return __sync_bool_compare_and_swap(ptr, exp_val, new_val)
+
+# These functions will probably trigger all sorts of warnings related to
+# aliasing issues. Good thing Python is compiled with -fno-strict-aliasing ;)
+
+cdef inline bint _c_atomic_cas_flt(float *ptr, float exp_val, float new_val):
+    cdef int *exp_ptr = <int *>&exp_val
+    cdef int *new_ptr = <int *>&new_val
+    return __sync_bool_compare_and_swap(<int *>ptr, exp_ptr[0], new_ptr[0])
+
+cdef inline bint _c_atomic_cas_dbl(double *ptr, double exp_val, double new_val):
+    cdef long long *exp_ptr = <long long *>&exp_val
+    cdef long long *new_ptr = <long long *>&new_val
+    return __sync_bool_compare_and_swap(<long long *>ptr, exp_ptr[0], new_ptr[0])

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -3587,7 +3587,7 @@ class ULongBufferProxyProperty(BaseBufferProxyProperty):
         if cython.compiled:
             _c_buffer_proxy_atomic_add[cython.ulonglong](self, obj, value)
         else:
-            _buffer_proxy_add(self, obj, 'B', value)
+            _buffer_proxy_add(self, obj, 'Q', value)
 
 @cython.cclass
 class LongBufferProxyProperty(BaseBufferProxyProperty):

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -3258,11 +3258,12 @@ if cython.compiled:
         mfence_full()   # release
 
     @cython.cfunc
+    @cython.inline
     @cython.locals(self = BaseBufferProxyProperty, obj = BufferProxyObject,
         exp_val = numeric_A, new_val = numeric_A, ptr = 'numeric_A *')
     def _c_buffer_proxy_atomic_cas(self, obj, exp_val, new_val):
         if obj is None or (obj.none_bitmap & self.mask):
-            return True
+            return False
         elif obj.pybuf.readonly:
             raise TypeError('cannot set attribute in read-only buffer')
         assert (obj.offs + self.offs + cython.sizeof(exp_val)) <= obj.pybuf.len   #lint:ok
@@ -3276,11 +3277,12 @@ if cython.compiled:
             return _c_atomic_cas(ptr, exp_val, new_val)
 
     @cython.cfunc
+    @cython.inline
     @cython.locals(self = BaseBufferProxyProperty, obj = BufferProxyObject,
         value = numeric_A, ptr = 'numeric_A *')
     def _c_buffer_proxy_atomic_add(self, obj, value):
         if obj is None or (obj.none_bitmap & self.mask):
-            return True
+            return
         elif obj.pybuf.readonly:
             raise TypeError('cannot set attribute in read-only buffer')
         assert (obj.offs + self.offs + cython.sizeof(value)) <= obj.pybuf.len   #lint:ok

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -3181,6 +3181,9 @@ class BaseBufferProxyProperty(object):
     def __set__(self, obj, value):
         raise TypeError("Proxy objects are read-only")
 
+    def cas(self, obj, exp_val, new_val):
+        raise TypeError("Proxy objects are read-only")
+
     def __delete__(self, obj):
         raise TypeError("Proxy objects are read-only")
 
@@ -3254,6 +3257,24 @@ if cython.compiled:
             cython.cast(cython.p_uchar, obj.pybuf.buf) + obj.offs + self.offs)[0] = elem   #lint:ok
         mfence_full()   # release
 
+    @cython.cfunc
+    @cython.locals(self = BaseBufferProxyProperty, obj = BufferProxyObject,
+        exp_val = numeric_A, new_val = numeric_A, ptr = 'numeric_A *')
+    def _c_buffer_proxy_cas(self, obj, exp_val, new_val):
+        if obj is None or (obj.none_bitmap & self.mask):
+            return True
+        elif obj.pybuf.readonly:
+            raise TypeError('cannot set attribute in read-only buffer')
+        assert (obj.offs + self.offs + cython.sizeof(exp_val)) <= obj.pybuf.len   #lint:ok
+        ptr = cython.cast('numeric_A *',
+            cython.cast(cython.p_uchar, obj.pybuf.buf) + obj.offs + self.offs)
+        if numeric_A is cython.float:
+            return _c_atomic_cas_flt(ptr, exp_val, new_val)
+        elif numeric_A is cython.double:
+            return _c_atomic_cas_dbl(ptr, exp_val, new_val)
+        else:
+            return _c_atomic_cas(ptr, exp_val, new_val)
+
 else:
     def _buffer_proxy_get(self, obj, code):
         if obj is None:
@@ -3266,6 +3287,15 @@ else:
     def _buffer_proxy_set(self, obj, code, elem):
         if obj is not None and not (obj.none_bitmap & self.mask):
             struct.pack_into(code, obj.buf, obj.offs + self.offs, elem)
+
+    def _buffer_proxy_cas(self, obj, code, exp_val, new_val):
+        # XXX: This is not atomic!
+        if obj is not None and not (obj.none_bitmap & self.mask):
+            tmp = struct.unpack_from(code, obj.buf, obj.offs + self.offs)[0]
+            if tmp == exp_val:
+                struct.pack_into(code, obj.buf, obj.offs + self.offs, new_val)
+                return True
+            return False
 
 
 @cython.cclass
@@ -3286,6 +3316,13 @@ class BoolBufferProxyProperty(BaseBufferProxyProperty):
         else:
             _buffer_proxy_set(self, obj, 'B', elem)
 
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.uchar, new_val = cython.uchar)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.uchar](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'B', exp_val, new_val)
+
 
 @cython.cclass
 class UByteBufferProxyProperty(BaseBufferProxyProperty):
@@ -3304,6 +3341,13 @@ class UByteBufferProxyProperty(BaseBufferProxyProperty):
             _c_buffer_proxy_set_gen[cython.uchar](self, obj, elem)
         else:
             _buffer_proxy_set(self, obj, 'B', elem)
+
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.uchar, new_val = cython.uchar)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.uchar](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'B', exp_val, new_val)
 
 
 @cython.cclass
@@ -3324,6 +3368,13 @@ class ByteBufferProxyProperty(BaseBufferProxyProperty):
         else:
             _buffer_proxy_set(self, obj, 'b', elem)
 
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.char, new_val = cython.char)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.char](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'b', exp_val, new_val)
+
 @cython.cclass
 class UShortBufferProxyProperty(BaseBufferProxyProperty):
     stride = cython.sizeof(cython.ushort) if cython.compiled else struct.Struct('H').size
@@ -3341,6 +3392,13 @@ class UShortBufferProxyProperty(BaseBufferProxyProperty):
             _c_buffer_proxy_set_gen[cython.ushort](self, obj, elem)
         else:
             _buffer_proxy_set(self, obj, 'H', elem)
+
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.ushort, new_val = cython.ushort)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.ushort](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'H', exp_val, new_val)
 
 @cython.cclass
 class ShortBufferProxyProperty(BaseBufferProxyProperty):
@@ -3360,6 +3418,13 @@ class ShortBufferProxyProperty(BaseBufferProxyProperty):
         else:
             _buffer_proxy_set(self, obj, 'h', elem)
 
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.short, new_val = cython.short)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.short](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'h', exp_val, new_val)
+
 @cython.cclass
 class UIntBufferProxyProperty(BaseBufferProxyProperty):
     stride = cython.sizeof(cython.uint) if cython.compiled else struct.Struct('I').size
@@ -3378,6 +3443,13 @@ class UIntBufferProxyProperty(BaseBufferProxyProperty):
         else:
             _buffer_proxy_set(self, obj, 'I', elem)
 
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.uint, new_val = cython.uint)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.uint](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'I', exp_val, new_val)
+
 @cython.cclass
 class IntBufferProxyProperty(BaseBufferProxyProperty):
     stride = cython.sizeof(cython.int) if cython.compiled else struct.Struct('i').size
@@ -3395,6 +3467,13 @@ class IntBufferProxyProperty(BaseBufferProxyProperty):
             _c_buffer_proxy_set_gen[cython.int](self, obj, elem)
         else:
             _buffer_proxy_set(self, obj, 'i', elem)
+
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.int, new_val = cython.int)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.int](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'i', exp_val, new_val)
 
 @cython.cclass
 class ULongBufferProxyProperty(BaseBufferProxyProperty):
@@ -3424,6 +3503,13 @@ class ULongBufferProxyProperty(BaseBufferProxyProperty):
         else:
             _buffer_proxy_set(self, obj, 'Q', elem)
 
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.ulonglong, new_val = cython.ulonglong)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.ulonglong](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'Q', exp_val, new_val)
+
 @cython.cclass
 class LongBufferProxyProperty(BaseBufferProxyProperty):
     stride = cython.sizeof(cython.longlong) if cython.compiled else struct.Struct('q').size
@@ -3441,6 +3527,13 @@ class LongBufferProxyProperty(BaseBufferProxyProperty):
             _c_buffer_proxy_set_gen[cython.longlong](self, obj, elem)
         else:
             _buffer_proxy_set(self, obj, 'q', elem)
+
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.longlong, new_val = cython.longlong)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.longlong](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'q', exp_val, new_val)
 
 @cython.cclass
 class DoubleBufferProxyProperty(BaseBufferProxyProperty):
@@ -3460,6 +3553,13 @@ class DoubleBufferProxyProperty(BaseBufferProxyProperty):
         else:
             _buffer_proxy_set(self, obj, 'd', elem)
 
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.double, new_val = cython.double)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.double](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'd', exp_val, new_val)
+
 @cython.cclass
 class FloatBufferProxyProperty(BaseBufferProxyProperty):
     stride = cython.sizeof(cython.float) if cython.compiled else struct.Struct('f').size
@@ -3477,6 +3577,13 @@ class FloatBufferProxyProperty(BaseBufferProxyProperty):
             _c_buffer_proxy_set_gen[cython.float](self, obj, elem)
         else:
             _buffer_proxy_set(self, obj, 'f', elem)
+
+    @cython.locals(obj = BufferProxyObject, exp_val = cython.float, new_val = cython.float)
+    def cas(self, obj, exp_val, new_val):
+        if cython.compiled:
+            return _c_buffer_proxy_cas[cython.float](self, obj, exp_val, new_val)
+        else:
+            return _buffer_proxy_cas(self, obj, 'f', exp_val, new_val)
 
 @cython.cclass
 class BytesBufferProxyProperty(BaseBufferProxyProperty):

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -3315,7 +3315,7 @@ else:
             if tmp == exp_val:
                 struct.pack_into(code, obj.buf, obj.offs + self.offs, new_val)
                 return True
-            return False
+        return False
 
     def _buffer_proxy_add(self, obj, code, value):
         if obj is not None and not (obj.none_bitmap & self.mask):
@@ -3347,13 +3347,6 @@ class BoolBufferProxyProperty(BaseBufferProxyProperty):
             return _c_buffer_proxy_atomic_cas[cython.uchar](self, obj, exp_val, new_val)
         else:
             return _buffer_proxy_cas(self, obj, 'B', exp_val, new_val)
-
-    @cython.locals(obj = BufferProxyObject, value = cython.uchar)
-    def add(self, obj, value):
-        if cython.compiled:
-            _c_buffer_proxy_atomic_add[cython.uchar](self, obj, value)
-        else:
-            _buffer_proxy_add(self, obj, 'B', value)
 
 
 @cython.cclass

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -4719,7 +4719,7 @@ class MappedArrayProxyBase(_ZipMapBase):
         proxy_class = self.proxy_class
         index = self.index
         idmap = self.idmap
-        buf = self.buf
+        buf = self.wr_buf
 
         if proxy_class is not None:
             proxy_class_new = functools.partial(proxy_class.__new__, proxy_class)
@@ -4745,7 +4745,7 @@ class MappedArrayProxyBase(_ZipMapBase):
         proxy_class = self.proxy_class
         index = self.index
         idmap = self.idmap
-        buf = self.buf
+        buf = self.wr_buf
 
         if proxy_class is not None:
             proxy_class_new = functools.partial(proxy_class.__new__, proxy_class)

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -2447,15 +2447,34 @@ class WriteableMappingTest(unittest.TestCase):
         proxy = self.schema.unpack_from(buf, 0)
 
         self.assertFalse(type(proxy).Bx.cas(proxy, 1, 0))
+        self.assertEqual(proxy.Bx, 0)
+
         self.assertFalse(type(proxy).bx.cas(proxy, 1, 0))
+        self.assertEqual(proxy.bx, 0)
+
         self.assertFalse(type(proxy).Hx.cas(proxy, 1, 0))
+        self.assertEqual(proxy.Hx, 0)
+
         self.assertFalse(type(proxy).hx.cas(proxy, 1, 0))
+        self.assertEqual(proxy.hx, 0)
+
         self.assertFalse(type(proxy).Ix.cas(proxy, 1, 0))
+        self.assertEqual(proxy.Ix, 0)
+
         self.assertFalse(type(proxy).ix.cas(proxy, 1, 0))
+        self.assertEqual(proxy.ix, 0)
+
         self.assertFalse(type(proxy).Qx.cas(proxy, 1, 0))
+        self.assertEqual(proxy.Qx, 0)
+
         self.assertFalse(type(proxy).qx.cas(proxy, 1, 0))
-        self.assertFalse(type(proxy).dx.cas(proxy, 1, 0))
-        self.assertFalse(type(proxy).fx.cas(proxy, 1, 0))
+        self.assertEqual(proxy.qx, 0)
+
+        self.assertFalse(type(proxy).dx.cas(proxy, 1.0, 0.0))
+        self.assertAlmostEqual(proxy.dx, 0.0)
+
+        self.assertFalse(type(proxy).fx.cas(proxy, 1.0, 0.0))
+        self.assertAlmostEqual(proxy.fx, 0.0)
 
     def testWriteableAdd(self):
         n = self.single_value

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -2446,34 +2446,34 @@ class WriteableMappingTest(unittest.TestCase):
         self.schema.pack_into(n, buf, 0)
         proxy = self.schema.unpack_from(buf, 0)
 
-        self.assertFalse(type(proxy).Bx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Bx.cas(proxy, 1, 2))
         self.assertEqual(proxy.Bx, 0)
 
-        self.assertFalse(type(proxy).bx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).bx.cas(proxy, 1, 2))
         self.assertEqual(proxy.bx, 0)
 
-        self.assertFalse(type(proxy).Hx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Hx.cas(proxy, 1, 2))
         self.assertEqual(proxy.Hx, 0)
 
-        self.assertFalse(type(proxy).hx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).hx.cas(proxy, 1, 2))
         self.assertEqual(proxy.hx, 0)
 
-        self.assertFalse(type(proxy).Ix.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Ix.cas(proxy, 1, 2))
         self.assertEqual(proxy.Ix, 0)
 
-        self.assertFalse(type(proxy).ix.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).ix.cas(proxy, 1, 2))
         self.assertEqual(proxy.ix, 0)
 
-        self.assertFalse(type(proxy).Qx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Qx.cas(proxy, 1, 2))
         self.assertEqual(proxy.Qx, 0)
 
-        self.assertFalse(type(proxy).qx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).qx.cas(proxy, 1, 2))
         self.assertEqual(proxy.qx, 0)
 
-        self.assertFalse(type(proxy).dx.cas(proxy, 1.0, 0.0))
+        self.assertFalse(type(proxy).dx.cas(proxy, 1.0, 2.0))
         self.assertAlmostEqual(proxy.dx, 0.0)
 
-        self.assertFalse(type(proxy).fx.cas(proxy, 1.0, 0.0))
+        self.assertFalse(type(proxy).fx.cas(proxy, 1.0, 2.0))
         self.assertAlmostEqual(proxy.fx, 0.0)
 
     def testWriteableAdd(self):

--- a/tests/mapped_struct.py
+++ b/tests/mapped_struct.py
@@ -2376,8 +2376,9 @@ class WriteableMappingTest(unittest.TestCase):
         values = [self.single_value]
         with tempfile.NamedTemporaryFile() as destfile:
             self.mapped_class.build(values, destfile = destfile, idmap = {})
-            proxy = self.mapped_class.map_file(destfile, read_only = False)[0]
-            self._assert_load_store(proxy)
+            lst = self.mapped_class.map_file(destfile, read_only = False)
+            for proxy in lst:
+                self._assert_load_store(proxy)
 
     def testWriteableZip(self):
         values = [self.single_value]
@@ -2393,3 +2394,109 @@ class WriteableMappingTest(unittest.TestCase):
                 zf = zipfile.ZipFile(tempzip, 'r')
                 proxy = self.mapped_class.map_file(zf.open('bundle'), read_only = False)[0]
                 self._assert_load_store(proxy)
+
+    def testWriteableCasSuccess(self):
+        n = self.single_value
+        buf = bytearray(1000)
+        self.schema.pack_into(n, buf, 0)
+        proxy = self.schema.unpack_from(buf, 0)
+
+        # We test not only that the member matches the expected value,
+        # but also that adjacent members weren't modified.
+
+        self.assertTrue(type(proxy).Bx.cas(proxy, 0, 1))
+        self.assertEqual(proxy.Bx, 1)
+        self.assertEqual(proxy.bx, 0)
+
+        self.assertTrue(type(proxy).bx.cas(proxy, 0, -1))
+        self.assertEqual(proxy.bx, -1)
+        self.assertEqual(proxy.Bx + proxy.bx, 0)
+
+        self.assertTrue(type(proxy).Hx.cas(proxy, 0, 1))
+        self.assertEqual(proxy.Hx, 1)
+        self.assertEqual(proxy.hx, 0)
+
+        self.assertTrue(type(proxy).hx.cas(proxy, 0, -1))
+        self.assertEqual(proxy.Hx + proxy.hx, 0)
+
+        self.assertTrue(type(proxy).Ix.cas(proxy, 0, 1))
+        self.assertEqual(proxy.Ix, 1)
+        self.assertEqual(proxy.ix, 0)
+
+        self.assertTrue(type(proxy).ix.cas(proxy, 0, -1))
+        self.assertEqual(proxy.Ix + proxy.ix, 0)
+
+        self.assertTrue(type(proxy).Qx.cas(proxy, 0, 1))
+        self.assertEqual(proxy.Qx, 1)
+        self.assertEqual(proxy.qx, 0)
+
+        self.assertTrue(type(proxy).qx.cas(proxy, 0, -1))
+        self.assertEqual(proxy.Qx + proxy.qx, 0)
+
+        self.assertTrue(type(proxy).dx.cas(proxy, 0.0, 1.0))
+        self.assertAlmostEqual(proxy.dx, 1.0)
+        self.assertAlmostEqual(proxy.fx, 0.0)
+
+        self.assertTrue(type(proxy).fx.cas(proxy, 0.0, -1.0))
+        self.assertAlmostEqual(proxy.dx + proxy.fx, 0.0)
+
+    def testWriteableCasFail(self):
+        n = self.single_value
+        buf = bytearray(1000)
+        self.schema.pack_into(n, buf, 0)
+        proxy = self.schema.unpack_from(buf, 0)
+
+        self.assertFalse(type(proxy).Bx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).bx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Hx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).hx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Ix.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).ix.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).Qx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).qx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).dx.cas(proxy, 1, 0))
+        self.assertFalse(type(proxy).fx.cas(proxy, 1, 0))
+
+    def testWriteableAdd(self):
+        n = self.single_value
+        buf = bytearray(1000)
+        self.schema.pack_into(n, buf, 0)
+        proxy = self.schema.unpack_from(buf, 0)
+
+        # We test not only that the member matches the expected value,
+        # but also that adjacent members weren't modified.
+        type(proxy).Bx.add(proxy, 1)
+        self.assertEqual(proxy.Bx, 1)
+        self.assertEqual(proxy.bx, 0)
+
+        type(proxy).bx.add(proxy, -1)
+        self.assertEqual(proxy.bx, -1)
+        self.assertEqual(proxy.Bx + proxy.bx, 0)
+
+        type(proxy).Hx.add(proxy, 1)
+        self.assertEqual(proxy.Hx, 1)
+        self.assertEqual(proxy.hx, 0)
+
+        type(proxy).hx.add(proxy, -1)
+        self.assertEqual(proxy.Hx + proxy.hx, 0)
+
+        type(proxy).Ix.add(proxy, 1)
+        self.assertEqual(proxy.Ix, 1)
+        self.assertEqual(proxy.ix, 0)
+
+        type(proxy).ix.add(proxy, -1)
+        self.assertEqual(proxy.Ix + proxy.ix, 0)
+
+        type(proxy).Qx.add(proxy, 1)
+        self.assertEqual(proxy.Qx, 1)
+        self.assertEqual(proxy.qx, 0)
+
+        type(proxy).qx.add(proxy, -1)
+        self.assertEqual(proxy.Qx + proxy.qx, 0)
+
+        type(proxy).dx.add(proxy, 1.0)
+        self.assertAlmostEqual(proxy.dx, 1.0)
+        self.assertAlmostEqual(proxy.fx, 0.0)
+
+        type(proxy).fx.add(proxy, -1.0)
+        self.assertAlmostEqual(proxy.dx + proxy.fx, 0.0)


### PR DESCRIPTION
This PR implements both atomic compare-and-swap and atomic add on numeric proxy properties. When cython is not being used, these methods are not atomic (And they can't be, unless we use kernel-level synchronization).

Memory order is implied to be sequentially consistent due to the usage of gcc's __sync* builtins.