### PR TITLE
Fix mapped tuple long headers

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -7,6 +7,15 @@ The format is largely inspired by keepachangelog_.
 
 .. _0.1.1:
 
+v0.7.2 - Unreleased
+===================
+
+Bugfixes
+--------
+
+- Fix mapped_tuple pack_into. If long headers were used, it would
+  unintentionally expand the given buffer.
+
 v0.7.1 - 2019-06-13
 ===================
 

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -709,7 +709,7 @@ class mapped_tuple(tuple):
                 buf[offs+1:offs+4] = _struct_l_I.pack(objlen)[:3]
                 offs += 4
             else:
-                buf[offs+1:offs+8] = '\xff\xff\xff\xff\xff\xff\xff'
+                buf[offs+1:offs+8] = '\xff\xff\xff\xff\xff\xff'
                 buf[offs+8:offs+12] = _struct_l_Q.pack(objlen)
                 offs += 12
 


### PR DESCRIPTION
Fix mapped_tuple pack_into. If long headers were used, it would
unintentionally expand the given buffer.