### PR TITLE
Fix MappedMappingProxyBase value deduplication

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -5,6 +5,15 @@ All notable changes to this project will be documented here.
 
 The format is largely inspired by keepachangelog_.
 
+v0.8.1 - 2019-09-11
+===================
+
+Bugfixes
+--------
+
+- Fix MappedMappingProxyBase deduplication. It was scarmbling values
+  if duplicates were not contiguous.
+
 v0.8.0 - 2019-08-08
 ===================
 

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -11,7 +11,7 @@ v0.8.1 - 2019-09-11
 Bugfixes
 --------
 
-- Fix MappedMappingProxyBase deduplication. It was scarmbling values
+- Fix MappedMappingProxyBase deduplication. It was scrambling values
   if duplicates were not contiguous.
 
 v0.8.0 - 2019-08-08

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ else:
     extra['ext_modules'] = lazy_modules()
     extra['setup_requires'] = setup_requires
 
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 
 version_path = os.path.join(os.path.dirname(__file__), 'sharedbuffers', '_version.py')
 if not os.path.exists(version_path):

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -8126,9 +8126,11 @@ def _iter_values_dump_keys(items, keys_file, value_cache_size = 1024):
     for key, value in items:
         if value not in value_cache:
             yield value
-            value_cache[value] = value
             i += 1
-        dump((key, i), keys_file, 2)
+            value_cache[value] = i
+            dump((key, i), keys_file, 2)
+        else:
+            dump((key, value_cache[value]), keys_file, 2)
     keys_file.flush()
 
 def _iter_key_dump(keys_file):


### PR DESCRIPTION
It was scrambling values when duplicates weren't contiguous, since
it was emitting the wrong index for those cases.