### PR TITLE
Fix run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,6 +8,7 @@ PYTHON_PREFIX=${PYTHON_PREFIX:-${PYTHON_DEFAULT}/}
 echo Python bin: ${PYTHON_PREFIX}
 ${PYTHON_PREFIX}python --version
 
+${PYTHON_PREFIX}pip install $(fgrep Cython requirements.txt)
 ${PYTHON_PREFIX}pip install -r requirements.txt
 
 ${PYTHON_PREFIX}python setup.py test


### PR DESCRIPTION
Cython needs to be preinstalled before installing requirements.txt,
as some dependencies need it preinstalled and pip won't guarantee
installation order.