### PR TITLE
Buffer reference handling fixes

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -5,6 +5,16 @@ All notable changes to this project will be documented here.
 
 The format is largely inspired by keepachangelog_.
 
+v0.9.2 - Unreleased
+===================
+
+Bugfixes
+--------
+
+- Fix buffer acquisition error handling to prevent the possibility of
+  double-release or other buffer reference mismanagement if an error
+  happens during the GetBuffer call.
+
 v0.9.1 - 2021-03-25
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ else:
     extra['ext_modules'] = lazy_modules()
     extra['setup_requires'] = setup_requires
 
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 
 version_path = os.path.join(os.path.dirname(__file__), 'sharedbuffers', '_version.py')
 if not os.path.exists(version_path):


### PR DESCRIPTION
Fix buffer acquisition error handling to prevent the possibility of
double-release or other buffer reference mismanagement if an error
happens during the GetBuffer call.