### PR TITLE
CORE-4190: Py3 perf fixes

### DIFF
--- a/sharedbuffers/mapped_struct.pxd
+++ b/sharedbuffers/mapped_struct.pxd
@@ -1,6 +1,7 @@
 from cpython.buffer cimport PyBUF_SIMPLE, PyBUF_WRITABLE, PyBUF_STRIDED_RO, PyObject_GetBuffer, PyBuffer_Release
 from cpython.object cimport Py_EQ, Py_NE, Py_LT, Py_LE, Py_GT, Py_GE
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from cpython.array cimport array
 from libc.string cimport memcpy, memcmp
 from libc.math cimport isinf, isnan
 

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -1010,7 +1010,7 @@ class mapped_list(list):
                 rv = w.cast(dtype)
             else:
                 rv = array(dtype)
-                rv.frombytes(w)
+                rv.fromstring(w)
         elif dchar == b'q' or dchar == b'Q':
             if dchar == b'q':
                 dtype = 'l'
@@ -1026,7 +1026,7 @@ class mapped_list(list):
                 rv = q.cast(dtype)
             else:
                 rv = array(dtype)
-                rv.frombytes(q)
+                rv.fromstring(q)
         elif dchar == b'd':
             dtype = 'd'
             objlen, = _struct_l_Q.unpack(buf[offs:offs+8])
@@ -1037,7 +1037,7 @@ class mapped_list(list):
                 rv = q.cast(dtype)
             else:
                 rv = array(dtype)
-                rv.frombytes(q)
+                rv.fromstring(q)
         elif dchar == b't' or dchar == b'T':
             if dchar == b't':
                 dtype = 'l'
@@ -1051,7 +1051,10 @@ class mapped_list(list):
             offs += 8
             q = buf[offs:offs+itemsize*objlen]
             index = array(dtype)
-            index.frombytes(q)
+            if python3:
+                index.frombytes(q)
+            else:
+                index.fromstring(q)
 
             if idmap is None:
                 idmap = {}

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -6239,6 +6239,8 @@ class NumericIdMapper(_CZipMapBase):
         dtypemax = cython.ulonglong,
     )
 
+    BUILD_BUFFER_SIZE = 1000000
+
     @property
     def buf(self):
         return self._buf
@@ -6545,12 +6547,13 @@ class NumericIdMapper(_CZipMapBase):
                 ('key', dtype),
                 ('value', dtype),
             ])
-            ppartbuf = partbuf = numpy.empty((1000000, 2), npuint64)
+            bufsize = cls.BUILD_BUFFER_SIZE
+            ppartbuf = partbuf = numpy.empty((bufsize, 2), npuint64)
             void_dt = numpy.dtype((numpy.void, struct_dt.itemsize))
             concatenate = numpy.concatenate
             while 1:
                 partpos = 0
-                for k,i in islice(initializer, 1000000):
+                for k,i in islice(initializer, bufsize):
                     # Add the index item
                     ppartbuf[partpos, 0] = k
                     ppartbuf[partpos, 1] = i


### PR DESCRIPTION
The many differences between Py3 and Py2 forced a few changes
that derailed performance, at times considerably. These are a few
fixes that recover most of the performance lost:

- cimport array.array to get direct access to the buffer
  for fast index iteration, as regular iteration is quite slow
  in py3
- Precompute bytes([x]) for all x at import time, and use a
  lookup list instead, as constructing the bytes manually, while
  relatively fast, is still slow compared to the py2 idiom it
  replaces and in a critical path
- Use mostly byte typecodes, avoid unicode as it forces an
  encode/decode step that's quite onerous. Still accept them
  from client code, but use bytes internally as much as possible.
- array(dtype, initializer) is very slow in py3. Replace it
  with the equivalent but somehow faster frombytes() when the
  initializer is a memoryview
- Avoid constructing arrays if a memoryview can be used instead,
  as py3 typed memoryviews behave like arrays in any case.
- Use array/memoryview tolist when possible, as it's quite optimized
  and much faster than list(x).
- Build idmapper indexes directly into numpy arrays. Py3 ints are
  slower than py2 ints by virtue of being arbitrary precision. The
  difference is tiny but it adds up. Building the index directly
  into a numpy array with cython's typed memoryviews support for
  direct and native access makes a big difference. Allows building
  big 1M arrays directly instead of using 1k batches, avoiding
  a whole sort step.