### PR TITLE
Fix base GenericFileMapper.map_file implementation in py 3.10

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -36,6 +36,7 @@ Bugfixes
 --------
 
 - Pack timestamps used for ``date`` and ``datetime`` objects in UTC
+- Fix GenericFileMapper's base implementation for zip files in python 3.10
 
 Technical Tasks
 ---------------

--- a/sharedbuffers/mapped_struct.py
+++ b/sharedbuffers/mapped_struct.py
@@ -4899,7 +4899,11 @@ class GenericFileMapper(_ZipMapBase):
             access = mmap.ACCESS_READ
         else:
             access = mmap.ACCESS_WRITE
-        buf = mmap.mmap(fileobj.fileno(), size + offset - map_start,
+        if hasattr(fileobj, "_file"):
+            fileno = fileobj._file.fileno()
+        else:
+            fileno = fileobj.fileno()
+        buf = mmap.mmap(fileno, size + offset - map_start,
             flags = mmap.MAP_SHARED, access = access, offset = map_start)
         return buffer_with_offset(buf, offset - map_start, size), buf
 


### PR DESCRIPTION
When used with zipfiles it would not find the fileno